### PR TITLE
Disallow shebangs inside expressions

### DIFF
--- a/standard/dhall.abnf
+++ b/standard/dhall.abnf
@@ -1018,5 +1018,7 @@ non-empty-list-literal =
 ; `#!` as a line comment only on the first lines
 shebang = "#!" *not-end-of-line end-of-line
 
-; This just adds surrounding whitespace for the top-level of the program
-complete-expression = *shebang whsp expression whsp [ line-comment-prefix ]
+complete-expression = whsp expression whsp
+
+; This just adds surrounding whitespace for the top-level of the program in a Dhall file.
+complete-dhall-file = *shebang complete-expression [ line-comment-prefix ]


### PR DESCRIPTION
https://github.com/dhall-lang/dhall-lang/issues/1357

According to the discussion in the issue, the Haskell parser already ignores shebangs inside expressions. This PR fixes the ABNF grammar so that a `complete-dhall-file` may contain shebangs but `complete-expression` may not.

