### PR TITLE
Fix typo in the example about type-level List

### DIFF
--- a/standard/function-check.md
+++ b/standard/function-check.md
@@ -119,7 +119,7 @@ For example, these are type-level functions permitted by the above rule:
 
     List
 
-    λ(m : Type) → [ m ] → m
+    λ(m : Type) → m → [ m ]
 
 When `c₀ = Type` and `c₁ = Kind` you get functions from terms to types (i.e.
 "dependent" types):


### PR DESCRIPTION
`List` goes from a type `m` to a type of `List m`, denoted in the example by `[ m ]`. This PR will fix the typo in the documentation.